### PR TITLE
Fixing foreign key constraints bug

### DIFF
--- a/admin/activation.php
+++ b/admin/activation.php
@@ -1,4 +1,4 @@
-<?php
+5<?php
 /**
  * Run all activation functions
  * 

--- a/admin/activation.php
+++ b/admin/activation.php
@@ -54,7 +54,7 @@ function bcr_setup_tables() {
     $sql = "CREATE TABLE $answers_table_name (
         answerID int(9) NOT NULL AUTO_INCREMENT,
         answerContent varchar(512) DEFAULT '' NOT NULL,
-        questionID int(9) NOT NULL,
+        questionID int(9) UNSIGNED NOT NULL,
         preDefinedAnswer int(1),
         PRIMARY KEY  (answerID),
         FOREIGN KEY  (questionID) REFERENCES $questions_table_name(questionID)
@@ -113,8 +113,8 @@ function bcr_setup_tables() {
 
     $sql = "CREATE TABLE $products_table_name (
         productID int(9) NOT NULL AUTO_INCREMENT,
-        categoryID int(9) NOT NULL,
-        brandID int(9) NOT NULL,
+        categoryID int(9) UNSIGNED NOT NULL,
+        brandID int(9) UNSIGNED NOT NULL,
         productName varchar(512) DEFAULT '' NOT NULL,
         PRIMARY KEY  (productID),
         FOREIGN KEY  (categoryID) REFERENCES $categories_table_name(categoryID),
@@ -181,7 +181,7 @@ function bcr_setup_tables() {
     $sql = "CREATE TABLE $review_forms_table_name (
         reviewFormID int(9) NOT NULL AUTO_INCREMENT,
         reviewFormName varchar(512) DEFAULT '' NOT NULL,
-        categoryID int(9) NOT NULL,
+        categoryID int(9) UNSIGNED NOT NULL,
         PRIMARY KEY  (reviewFormID),
         FOREIGN KEY  (categoryID) REFERENCES $categories_table_name(categoryID)
         ) $charset_collate;";
@@ -207,7 +207,7 @@ function bcr_setup_tables() {
     $sql = "CREATE TABLE $reviews_table_name (
         reviewID int(9) NOT NULL AUTO_INCREMENT,
         userID int(9) NOT NULL,
-        reviewFormID int(9) NOT NULL,
+        reviewFormID int(9) UNSIGNED NOT NULL,
         isShown BOOLEAN NOT NULL DEFAULT 1,
         PRIMARY KEY  (reviewID),
         FOREIGN KEY  (reviewFormID) REFERENCES $review_forms_table_name(reviewFormID),
@@ -223,7 +223,7 @@ function bcr_setup_tables() {
     $review_answers_table_name = $wpdb->prefix . "bcr_reviews_answers";
 
     $sql = "CREATE TABLE $review_answers_table_name (
-        reviewID int(9) NOT NULL,
+        reviewID int(9) UNSIGNED NOT NULL,
         answerID int(9) NOT NULL,
         PRIMARY KEY  (reviewID, answerID),
         FOREIGN KEY  (reviewID) REFERENCES $reviews_table_name(reviewID),

--- a/admin/activation.php
+++ b/admin/activation.php
@@ -54,7 +54,7 @@ function bcr_setup_tables() {
     $sql = "CREATE TABLE $answers_table_name (
         answerID int(9) NOT NULL AUTO_INCREMENT,
         answerContent varchar(512) DEFAULT '' NOT NULL,
-        questionID int(9) UNSIGNED NOT NULL,
+        questionID int(9) NOT NULL,
         preDefinedAnswer int(1),
         PRIMARY KEY  (answerID),
         FOREIGN KEY  (questionID) REFERENCES $questions_table_name(questionID)
@@ -224,7 +224,7 @@ function bcr_setup_tables() {
 
     $sql = "CREATE TABLE $review_answers_table_name (
         reviewID int(9) UNSIGNED NOT NULL,
-        answerID int(9) NOT NULL,
+        answerID int(9) UNSIGNED NOT NULL,
         PRIMARY KEY  (reviewID, answerID),
         FOREIGN KEY  (reviewID) REFERENCES $reviews_table_name(reviewID),
         FOREIGN KEY  (answerID) REFERENCES $answers_table_name(answerID)

--- a/admin/activation.php
+++ b/admin/activation.php
@@ -1,4 +1,4 @@
-5<?php
+<?php
 /**
  * Run all activation functions
  * 


### PR DESCRIPTION
I believe I have created the fix to this bug. I went through and double checked that all of the tables were being added in the correct order. I also changed a few data types where there was a constraint, specifically changing int(9) NOT NULL data types to int(9) UNSIGNED NOT NULL for attributes that were foreign key constraints in the child tables. This was due to the parent data type: int(9) NOT NULL AUTO INCREMENT not being allowed to have negative values while the child data type: int(9) NOT NULL does allow for negative values. 

I was able to drop all of the 1.custom tables in my database 2. deactivate the plugin 3. reactivate the plugin 4. and check that all the tables were still created the same. Whomever does this pull request should pull and make sure the same thing happens through that process.

NOTE: I was unable to recreate the error that Eric had so I am still unsure if this is a surefire fix. Let me know if there are any other suggestions.