### PR TITLE
replace wp_ with system prefix

### DIFF
--- a/admin/uploadInitialData.php
+++ b/admin/uploadInitialData.php
@@ -16,6 +16,7 @@ function bcr_init_tables() {
     foreach($lines as $key => $line ){
         $sql_command.= $wpdb->prepare($line);
     }
+    $sql_command = $wpdb->prepare(str_replace("wp_", $wpdb->prefix, $sql_command));
     dbDelta($sql_command);
 }
 


### PR DESCRIPTION
Fixes the auto upload of table entries to match whatever the prefix is of the system being uploaded to.