### PR TITLE
Filtering elementor settings

### DIFF
--- a/community_reviews_display_functions.php
+++ b/community_reviews_display_functions.php
@@ -7,10 +7,16 @@
 function bcr_filter_posts() {
     global $wpdb;
 
+    $posts_per_page = 4;
+
+    if ( ! empty( $_POST['posts_per_page'] ) ) {
+        $posts_per_page = intval(sanitize_text_field( $_POST['posts_per_page'] ) );
+    }
+
     $paged = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
     $args = array(
         'post_type'      => 'Community Reviews',
-        'posts_per_page' => 4,
+        'posts_per_page' => $posts_per_page,
         'paged'          => $paged,
     );
 

--- a/widgets/community-reviews-display.php
+++ b/widgets/community-reviews-display.php
@@ -28,7 +28,27 @@ class Community_Reviews_Display extends \Elementor\Widget_Base {
 	}
 
     protected function register_controls() {
+		$this->start_controls_section(
+			'content_section',
+			[
+				'label' => esc_html__( 'Content', 'textdomain' ),
+				'tab' => \Elementor\Controls_Manager::TAB_CONTENT,
+			]
+		);
 
+		$this->add_control(
+			'show_filters',
+			[
+				'label' => esc_html__( 'Show Filters', 'textdomain' ),
+				'type' => \Elementor\Controls_Manager::SWITCHER,
+				'label_on' => esc_html__( 'Show', 'textdomain' ),
+				'label_off' => esc_html__( 'Hide', 'textdomain' ),
+				'return_value' => 'yes',
+				'default' => 'yes',
+			]
+		);
+
+		$this->end_controls_section();
     }
 
     protected function render() {
@@ -38,11 +58,24 @@ class Community_Reviews_Display extends \Elementor\Widget_Base {
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.6/js/standalone/selectize.min.js" integrity="sha256-+C0A5Ilqmu4QcSPxrlGpaZxJ04VjsRjKu+G82kl5UJk=" crossorigin="anonymous"></script>
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.6/css/selectize.bootstrap3.min.css" integrity="sha256-ze/OEYGcFbPRmvCnrSeKbRTtjG4vGLHXgOqsyLFTRjg=" crossorigin="anonymous" />
 
-		<div class="community-reviews-display">
-			<div class="community-reviews-display-mobile-only">
+		<?php
+			if('yes' === $settings['show_filters']) {
+				echo '<div class="community-reviews-display">';
+				echo '<div class="community-reviews-display-mobile-only">';
+			} else {
+				echo '<div class="community-reviews-display" style="display: grid; grid-template-columns: 100%;">';
+				echo '<div class="community-reviews-display-mobile-only" style="display: none;">';
+			}
+		?>
 				<button id="community-reviews-display-mobile-button">Filters</button>
 			</div>
-			<div class="community-reviews-display-filter" id="community-reviews-display-filter">
+			<?php
+				if('yes' === $settings['show_filters']) {
+					echo '<div class="community-reviews-display-filter" id="community-reviews-display-filter">';
+				} else {
+					echo '<div class="community-reviews-display-filter" id="community-reviews-display-filter" style="display: none;">';
+				}
+			?>
 
 				<strong>Product Filters</strong>
 

--- a/widgets/community-reviews-display.php
+++ b/widgets/community-reviews-display.php
@@ -48,6 +48,19 @@ class Community_Reviews_Display extends \Elementor\Widget_Base {
 			]
 		);
 
+		$this->add_control(
+			'posts_per_page',
+			[
+				'type' => \Elementor\Controls_Manager::NUMBER,
+				'label' => esc_html__( 'Number of reviews per page', 'textdomain' ),
+				'placeholder' => '4',
+				'min' => 1,
+				'max' => 50,
+				'step' => 1,
+				'default' => 4,
+			]
+		);
+
 		$this->end_controls_section();
     }
 
@@ -305,7 +318,7 @@ class Community_Reviews_Display extends \Elementor\Widget_Base {
 
 					$args = array(
 						'post_type' 	 => 'Community Reviews',
-						'posts_per_page' => 4,
+						'posts_per_page' => $settings['posts_per_page'],
 						'paged'          => $paged,
 					);
 
@@ -367,6 +380,7 @@ class Community_Reviews_Display extends \Elementor\Widget_Base {
 					method: 'POST',
 					data: {
 						action: 'bcr_filter_posts',
+						posts_per_page: <?php echo $settings['posts_per_page'];?>,
 						sport: sport,
 						category: category,
 						brand: brand,


### PR DESCRIPTION
Testing requirements:
- Editing the filtering widget in Elementor shows two options: Show filters and number of posts per page
- Show filters toggle correctly hides the filters from view on both mobile and desktop
- Number of posts per page correctly changes the number of posts shown per page on both mobile and desktop
- Number of posts per page correctly changes the number of posts shown when the filter button is pressed